### PR TITLE
Fix border-radius typo in Pokedex CSS

### DIFF
--- a/src/components/Pokedex/Pokedex.css
+++ b/src/components/Pokedex/Pokedex.css
@@ -15,7 +15,7 @@
     background-color: rgba(252, 126, 47, 0.6);
     margin: 10px;
     flex-grow: 3;
-    border-radius: 10px 1px 1px 10x;
+    border-radius: 10px 1px 1px 10px;
 }
 
 .pokesearchresult-container {


### PR DESCRIPTION
## Summary
- correct border-radius value in `Pokedex.css`

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688417165e248331a73acd35e2302350