### PR TITLE
Fix incorrect error handling references

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,9 @@ async function fetchAllPokemon() {
     );
 
     if (!allPokemonResponse.ok) {
-      throw Error(`${response.status}: ${response.statusText}`);
+      throw Error(
+        `${allPokemonResponse.status}: ${allPokemonResponse.statusText}`
+      );
     }
 
     return await allPokemonResponse.json();

--- a/src/components/Pokedex/PokeCard/PokeCard.tsx
+++ b/src/components/Pokedex/PokeCard/PokeCard.tsx
@@ -12,7 +12,9 @@ function useSinglePokemonDetails(pokemon: any) {
           const pokemonDetailsResponse = await fetch(pokemon.url);
 
           if (!pokemonDetailsResponse.ok) {
-            throw Error(`${response.status}: ${response.statusText}`);
+            throw Error(
+              `${pokemonDetailsResponse.status}: ${pokemonDetailsResponse.statusText}`
+            );
           }
 
           setDetails(await pokemonDetailsResponse.json());


### PR DESCRIPTION
## Summary
- fix broken references in App and PokeCard when throwing errors

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68827b0dea6083318d94e335bbb2bd4c